### PR TITLE
[fix](jrasp-agent/pom.xml) 修改jose4j指定版本为最新1.0.4, 以修复mvn打包时版本指定错误的问题

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <jrasp.version>1.0.4</jrasp.version>
         <shade-prefix>jrasp</shade-prefix>
         <jetty.version>8.1.2.v20120308</jetty.version>
-        <jose4j.version>1.0.2</jose4j.version>
+        <jose4j.version>1.0.4</jose4j.version>
         <guava.version>19.0</guava.version>
         <asm.version>7.2</asm.version>
         <servlet.version>3.0.1</servlet.version>


### PR DESCRIPTION
当前父项目的pom设置有问题，指定了本地jose版本为1.0.2，但是实际jose版本设置为1.0.4，新clone的仓库无法编译并按照1.0.2版本的jose，导致项目无法打包编译通过