### PR TITLE
加固HookNativeMethod

### DIFF
--- a/jrasp-core/src/main/java/com/jrasp/agent/core/enhance/weaver/asm/EventWeaver.java
+++ b/jrasp-core/src/main/java/com/jrasp/agent/core/enhance/weaver/asm/EventWeaver.java
@@ -136,6 +136,7 @@ public class EventWeaver extends ClassVisitor implements Opcodes, AsmTypes, AsmM
                                 processControl(desc);
                                 final String wrapperNativeMethodName = NATIVE_PREFIX + name;
                                 Method wrapperMethod = new Method(access, wrapperNativeMethodName, desc);
+                                Method fakeWrapperMethod = new Method(access, getNativePrefix() + name, desc); //虚假wrapperMethod
                                 String owner = toInternalClassName(targetJavaClassName);
                                 if (!isStaticMethod()) {
                                     loadThis();
@@ -147,6 +148,7 @@ public class EventWeaver extends ClassVisitor implements Opcodes, AsmTypes, AsmM
                                     //wrapper的方法永远都是private
                                     mv.visitMethodInsn(Opcodes.INVOKESPECIAL, owner, wrapperMethod.getName(), wrapperMethod.getDescriptor(), false);
                                 }
+                                EventWeaver.this.addMethodNodes.add(fakeWrapperMethod);    //最终添加至addMethodNodes中。
                                 EventWeaver.this.addMethodNodes.add(wrapperMethod);
                                 loadReturn(Type.getReturnType(desc));
                                 push(namespace);

--- a/jrasp-core/src/main/java/com/jrasp/agent/core/enhance/weaver/asm/EventWeaver.java
+++ b/jrasp-core/src/main/java/com/jrasp/agent/core/enhance/weaver/asm/EventWeaver.java
@@ -10,6 +10,7 @@ import org.objectweb.asm.commons.JSRInlinerAdapter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -22,7 +23,7 @@ import static com.jrasp.agent.core.util.string.RaspStringUtils.toJavaClassName;
  */
 public class EventWeaver extends ClassVisitor implements Opcodes, AsmTypes, AsmMethods {
 
-    public final static String NATIVE_PREFIX = "$$JRASP$$";
+    public final static String NATIVE_PREFIX = getNativePrefix();
 
     private final static Logger logger = Logger.getLogger(EventWeaver.class.getName());
 
@@ -32,6 +33,22 @@ public class EventWeaver extends ClassVisitor implements Opcodes, AsmTypes, AsmM
     private final List<Method> addMethodNodes = new ArrayList();
     private final boolean isNativeMethodEnhanceSupported;
     private final ClassMatcher classMatcher;
+
+    //生成5-8位的随机NATIVE_PREFIX字符串，防止attacker直接调用$$JRASP$$从而escape native method hook.
+    public static String getNativePrefix(){
+        String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        Random random = new Random();
+        int length = random.nextInt(4)+5; //5-8位长度
+        StringBuilder sb = new StringBuilder();
+        sb.append("$$");
+        for (int i = 0; i < length; i++) {
+            int index = random.nextInt(characters.length());
+            char randomChar = characters.charAt(index);
+            sb.append(randomChar);
+        }
+        sb.append("$$");
+        return sb.toString();
+    }
 
     public EventWeaver(
             final boolean isNativeMethodEnhanceSupported,


### PR DESCRIPTION
生成随机`NATIVE_PREFIX`字符串，防止`Attacker Bypass RASP NativeMethodPrefix`。
#### 存在绕过风险
参考https://yzddmr6.com/posts/rasp-nativemethodprefix-bypass/
以`windows`执行`ProcessImpl#create`执行命令为例，攻击者在获得任意代码执行的前提下可通过反射得到`wrapper_create`方法。或可直接反射调用`$$JRASP$$create`方法来绕过检测。
```
for (Method m : processImplClass.getDeclaredMethods()) {
    if (m.getName().endsWith("create") && !m.getName().equals("create")) {
        System.out.println("[+] get prefix native method : " + m.getName());
        m.setAccessible(true);
        long processHandle = (Long) m.invoke(null, cmd, null, null, stdHandles, redirectErrorStream);
    }
}
```
#### 缓解措施
通过`getNativePrefix`方法获取随机前缀作为`native`方法前缀来缓解攻击者基于先验知识直接调用`$$JRASP$$create`方法。
```
public static String getNativePrefix(){
    String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
    Random random = new Random();
    int length = random.nextInt(4)+5; //5-8位长度
    StringBuilder sb = new StringBuilder();
    sb.append("$$");
    for (int i = 0; i < length; i++) {
        int index = random.nextInt(characters.length());
        char randomChar = characters.charAt(index);
        sb.append(randomChar);
    }
    sb.append("$$");
    return sb.toString();
}
```
此外，通过额外添加虚假`wrapperNativeMethod`来缓解问题。
```
Method fakeWrapperMethod = new Method(access, getNativePrefix() + name, desc); //虚假wrapperMethod
```
#### Hook后的类
![image](https://github.com/jvm-rasp/jrasp-agent/assets/65816951/fce20db7-e724-4159-b868-0b707adcf4a2)
